### PR TITLE
Add merchant fleet feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,14 @@ Apply the `pierate_ships` class to the primary Puppet Server node with the follo
 > **Note**: This module is under development and currently only supports the Datadog platform.
 
 ##### Required Parameters:
-  * `$auth_token` - API key for the observability platform.
-  * `$merchant_site` - API endpoint receiving Puppet data.
-  * `$merchant` - The observability platform we are shipping to.
+  * `$merchant_fleet` - The fleet of merchants to ship data to. This parameter accepts an Array of Structs that include the `merchant`, `auth_token`, and `site` (API URL) for each observability platform.
 
 **Example**:
 
 ```
 node 'puppet-primary.server.example.com' {
   class { 'pierate_ships':
-    auth_token    => '12345abcde',
-    merchant_site => 'https://api.datadoghq.com',
-    merchant      => 'datadog',
+    merchant_fleet => [{'merchant' => 'datadog', 'auth_token' => 'abcd1234, 'site' => 'https://api.datadoghq.com'}],
   }
 }
 ```

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,17 +2,31 @@
 #
 # @example
 #   include pierate_ships
+#
+# @param [String] pe_console
+#   The FQDN of the PE Console
+# @param [Array[Struct[{'merchant' => String[Enum['datadog']], 'auth_token' => String, 'site' => String,}]]] merchant_fleet
+#   The fleet of merchants to ship data to
+# @param [Boolean] run_reporting
+#   Whether to ship Puppet reports
+# @param [Boolean] event_reporting
+#   Whether to ship Puppet events
+# @param [Boolean] service_checks
+#   Whether to ship PE service checks
+# @param [Array] event_types
+#   The types of events to ship
+# @param [Optional[Array]] metric_filters
+#   Filters for metrics
 class pierate_ships (
   String $auth_token = undef,
   String $pe_console = $settings::report_server,
-  Enum['datadog'] $merchant = undef,
-  String $merchant_site = 'https://api.datadoghq.com',
+  Hash[String, Array] $merchant_fleet = undef,
   Boolean $run_reporting = false,
   Boolean $event_reporting = false,
   Boolean $service_checks = false,
   Array $event_types = ['orchestrator','rbac','classifier','pe-console','code-manager'],
   Optional[Array] $metric_filters = undef,
-){
+) {
   # Account for the differences in running on Primary Server or Agent Node
   if $facts[pe_server_version] != undef {
     $ini_setting    = 'pe_ini_setting'
@@ -29,42 +43,45 @@ class pierate_ships (
     $group          = 'puppet'
   }
 
-  file {'/etc/puppetlabs/pierate_ships':
+  file { '/etc/puppetlabs/pierate_ships':
     ensure => directory,
     owner  => $owner,
     group  => $group,
   }
 
-  # Secure credential data
-  $merchant_secrets = {
-    'api_key' => $auth_token,
-    'api_url' => $merchant_site,
-  }
-  $secrets = Deferred('pierate_ships::secure', [$merchant_secrets])
+  $merchant_fleet.each |$ship, $dock| {
+    # Secure credential data
+    $merchant_secrets = {
+      'api_key' => $dock[0],
+      'api_url' => $dock[1],
+    }
+    $secrets = Deferred('pierate_ships::secure', [$merchant_secrets])
 
-  file {"/etc/puppetlabs/pierate_ships/${merchant}":
-    ensure => directory,
-    owner  => $owner,
-    group  => $group,
-  }
+    file { "/etc/puppetlabs/pierate_ships/${ship}":
+      ensure => directory,
+      owner  => $owner,
+      group  => $group,
+    }
 
-  file { "/etc/puppetlabs/pierate_ships/${merchant}/settings.yaml":
-    ensure  => file,
-    owner   => $owner,
-    group   => $group,
-    mode    => '0640',
-    require => File["/etc/puppetlabs/pierate_ships/${merchant}"],
-    content => epp('pierate_ships/settings.yaml.epp'),
-    notify  => Service[$service],
-  }
-  file { "/etc/puppetlabs/pierate_ships/${merchant}/secrets.yaml":
-    ensure  => file,
-    owner   => $owner,
-    group   => $group,
-    mode    => '0600',
-    require => File["/etc/puppetlabs/pierate_ships/${merchant}"],
-    content => Sensitive(Deferred('inline_epp', [file('pierate_ships/secrets.yaml.epp'), $secrets])),
-    notify  => Service[$service],
+    file { "/etc/puppetlabs/pierate_ships/${ship}/settings.yaml":
+      ensure  => file,
+      owner   => $owner,
+      group   => $group,
+      mode    => '0640',
+      require => File["/etc/puppetlabs/pierate_ships/${ship}"],
+      content => epp('pierate_ships/settings.yaml.epp'),
+      notify  => Service[$service],
+    }
+
+    file { "/etc/puppetlabs/pierate_ships/${ship}/secrets.yaml":
+      ensure  => file,
+      owner   => $owner,
+      group   => $group,
+      mode    => '0600',
+      require => File["/etc/puppetlabs/pierate_ships/${ship}"],
+      content => Sensitive(Deferred('inline_epp', [file('pierate_ships/secrets.yaml.epp'), $secrets])),
+      notify  => Service[$service],
+    }
   }
 
   if $run_reporting {

--- a/manifests/pe_service_checks.pp
+++ b/manifests/pe_service_checks.pp
@@ -1,26 +1,29 @@
 # @summary This class adds the service check integration for Puppet Enterprise
 #
-# @example
-#   include pierate_ships::pe_service_checks
-class pierate_ships::pe_service_checks(
-  Enum['datadog'] $merchant = $pierate_ships::merchant,
-  Optional[String] $check_interval = '2',
-){
+# @param [Array[Struct[{'merchant' => String[Enum['datadog']], 'auth_token' => String, 'site' => String,}]]] merchant_fleet
+#   The fleet of merchants to ship data to
+# @param [String] check_interval
+#   Interval to run the service checks
+class pierate_ships::pe_service_checks (
+  Hash[String, Array] $merchant_fleet = $pierate_ships::merchant_fleet,
+  String $check_interval = '2',
+) {
+  $merchant_fleet.each |$ship| {
+    file { "/etc/puppetlabs/pierate_ships/${ship[0]}/pe_service_checks.rb":
+      ensure  => file,
+      owner   => 'pe-puppet',
+      group   => 'pe-puppet',
+      mode    => '0755',
+      require => File["/etc/puppetlabs/pierate_ships/${ship[0]}"],
+      source  => 'puppet:///modules/pierate_ships/pe_service_checks.rb',
+    }
 
-  file { "/etc/puppetlabs/pierate_ships/${merchant}/pe_service_checks.rb":
-    ensure  => file,
-    owner   => 'pe-puppet',
-    group   => 'pe-puppet',
-    mode    => '0755',
-    require => File["/etc/puppetlabs/pierate_ships/${merchant}"],
-    source  => 'puppet:///modules/pierate_ships/pe_service_checks.rb',
-  }
-
-  cron { 'pe_service_checks':
-    ensure  => present,
-    command => "/etc/puppetlabs/pierate_ships/${merchant}/pe_service_checks.rb",
-    user    => 'pe-puppet',
-    minute  => "*/${check_interval}",
-    require => File["/etc/puppetlabs/pierate_ships/${merchant}/pe_service_checks.rb"],
+    cron { 'pe_service_checks':
+      ensure  => present,
+      command => "/etc/puppetlabs/pierate_ships/${ship[0]}/pe_service_checks.rb",
+      user    => 'pe-puppet',
+      minute  => "*/${check_interval}",
+      require => File["/etc/puppetlabs/pierate_ships/${ship[0]}/pe_service_checks.rb"],
+    }
   }
 }

--- a/manifests/puppet_reports.pp
+++ b/manifests/puppet_reports.pp
@@ -1,12 +1,11 @@
 # @summary This class adds the puppet report integration for PE & OSP
 #
-# @example
-#   include pierate_ships::puppet_reports
-class pierate_ships::puppet_reports(
-  Enum['datadog'] $merchant = $pierate_ships::merchant,
+# @param [Array[Struct[{'merchant' => String[Enum['datadog']], 'auth_token' => String, 'site' => String,}]]] merchant_fleet
+#   The fleet of merchants to ship data to
+class pierate_ships::puppet_reports (
+  Hash[String, Array] $merchant_fleet = $pierate_ships::merchant_fleet,
 ) {
-
-  package {'puppetserver_dogapi':
+  package { 'puppetserver_dogapi':
     ensure   => present,
     name     => 'dogapi',
     provider => 'puppetserver_gem',
@@ -26,13 +25,15 @@ class pierate_ships::puppet_reports(
     $service        = 'puppetserver'
   }
 
-  Resource[$ini_subsetting] { "enable ${merchant} reporting":
-    ensure               => present,
-    path                 => '/etc/puppetlabs/puppet/puppet.conf',
-    section              => 'master',
-    setting              => 'reports',
-    subsetting           => $merchant,
-    subsetting_separator => ',',
-    notify               => Service[$service],
+  $merchant_fleet.each |$ship| {
+    Resource[$ini_subsetting] { "enable ${ship[0]} reporting":
+      ensure               => present,
+      path                 => '/etc/puppetlabs/puppet/puppet.conf',
+      section              => 'master',
+      setting              => 'reports',
+      subsetting           => $ship[0],
+      subsetting_separator => ',',
+      notify               => Service[$service],
+    }
   }
 }


### PR DESCRIPTION
# Summary

This commit refactors a number of parameters into a single parameter (`$pierate_ships::merchant_fleet`); allowing for the ability to iterate over a list of different observability platforms to configure shipping of Puppet data to those platforms.